### PR TITLE
Fix (RTU USB) failure to `select()` an invalid file descriptor

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,6 +157,23 @@ if test "x$with_libusb" != "xno"; then
         LIBUSB_LIBS="-lusb-1.0"
         AC_DEFINE(HAVE_LIBUSB, 1, [defined if libusb is available])
         have_libusb=yes
+
+        AC_MSG_CHECKING([for libusb pollfd accessibility])
+        AC_LANG_PUSH([C])
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <libusb-1.0/libusb.h>
+],[
+libusb_context *ctx = NULL;
+const struct libusb_pollfd** list = libusb_get_pollfds(ctx);
+/* Do not care about actual return value in this test,
+ * normally check for non-zero meaning to look in errno */
+]
+            )],
+            [AC_DEFINE(HAVE_LIBUSB_POLLFD, 1, [defined if libusb pollfd is available])
+             AC_MSG_RESULT([ok])
+            ],
+            [AC_MSG_RESULT([no])]
+        )
     ], [
         AC_MSG_ERROR(["libusb-1.0 not found. Please install libusb-1.0."])
     ])

--- a/src/modbus-rtu-usb.c
+++ b/src/modbus-rtu-usb.c
@@ -555,6 +555,12 @@ static int _modbus_rtu_usb_connect(modbus_t *ctx)
                     if (ctx->debug) {
                         printf("Got a list of %u libusb file descriptors to poll\n", j);
                     }
+                    /* FIXME: We might get more than one FD here.
+                     *  Some research is needed to check if they
+                     *  all should be polled. In that case maybe
+                     *  libmodbus should move from single ctx->s
+                     *  to an array of file descriptors/sockets.
+                     */
                     if (j == 1) {
                         ctx->s = pollfds[0]->fd;
                     }

--- a/src/modbus-rtu-usb.c
+++ b/src/modbus-rtu-usb.c
@@ -553,20 +553,20 @@ static int _modbus_rtu_usb_connect(modbus_t *ctx)
                     unsigned	j;
                     for (j=0; pollfds[j] != NULL; j++) {}
                     if (ctx->debug) {
-                        printf("Got a list of %u libusb file descriptors to poll", j);
+                        printf("Got a list of %u libusb file descriptors to poll\n", j);
                     }
                     if (j == 1) {
                         ctx->s = pollfds[0]->fd;
                     }
                 } else if (ctx->debug) {
-                    printf("Got no list of libusb file descriptors to poll");
+                    printf("Got no list of libusb file descriptors to poll\n");
                 }
             } else if (ctx->debug) {
-                printf("Got no libusb context to query for file descriptors to poll");
+                printf("Got no libusb context to query for file descriptors to poll\n");
             }
 #else
             if (ctx->debug) {
-                printf("Can not get a list of libusb file descriptors to poll from this libusb version");
+                printf("Can not get a list of libusb file descriptors to poll from this libusb version\n");
             }
 #endif	/* HAVE_LIBUSB_POLLFD */
             break;

--- a/src/modbus-rtu-usb.c
+++ b/src/modbus-rtu-usb.c
@@ -546,7 +546,29 @@ static int _modbus_rtu_usb_connect(modbus_t *ctx)
             }
 
             ctx_rtu_usb->device_handle = dev_handle;
-
+#if defined HAVE_LIBUSB_POLLFD && HAVE_LIBUSB_POLLFD
+            if (usb_ctx) {
+                const struct libusb_pollfd** pollfds = libusb_get_pollfds(usb_ctx);
+                if (pollfds) {
+                    unsigned	j;
+                    for (j=0; pollfds[j] != NULL; j++) {}
+                    if (ctx->debug) {
+                        printf("Got a list of %u libusb file descriptors to poll", j);
+                    }
+                    if (j == 1) {
+                        ctx->s = pollfds[0]->fd;
+                    }
+                } else if (ctx->debug) {
+                    printf("Got no list of libusb file descriptors to poll");
+                }
+            } else if (ctx->debug) {
+                printf("Got no libusb context to query for file descriptors to poll");
+            }
+#else
+            if (ctx->debug) {
+                printf("Can not get a list of libusb file descriptors to poll from this libusb version");
+            }
+#endif	/* HAVE_LIBUSB_POLLFD */
             break;
         }
 

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -377,7 +377,14 @@ int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
 
     /* Add a file descriptor to the set */
     FD_ZERO(&rset);
-    FD_SET(ctx->s, &rset);
+    if (ctx->s < 0) {
+        if (ctx->debug) {
+            /* we may not have an FD with e.g. libusb usage */
+            fprintf(stderr, "Using a backend without a file descriptor, will not select() on it.\n");
+        }
+    } else {
+        FD_SET(ctx->s, &rset);
+    }
 
     /* We need to analyse the message step by step.  At the first step, we want
      * to reach the function code because all packets contain this

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -437,7 +437,12 @@ int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
                 errno = saved_errno;
 #endif
             }
-            return -1;
+            if (ctx->s >= 0) {
+                return -1;
+            }
+            // else: We have at most tried some default FD's but not
+            // the (lacking) one for the backend, so fall through for
+            // its recv method anyway (e.g. query libusb directly).
         }
 
         rc = ctx->backend->recv(ctx, msg + msg_length, length_to_read);


### PR DESCRIPTION
Implementation of new libusb-based USB RTU for libmodbus, as proposed by @EchterAgo as part of https://github.com/networkupstools/nut/pull/2063 solution, involves direct libusb API communications in the new backend. As such, there is normally no file descriptor to `select()` for incoming data, as is the case with serial port or a network socket (TCP RTU).

After investigation done in https://github.com/networkupstools/nut/issues/2609 and related tickets (https://github.com/networkupstools/nut/issues/2289, https://github.com/networkupstools/nut/issues/2732) I am convinced that the technical issue is in this backend never initializing `ctx->s` so it remains `-1` from common allocation. The (generally platform-defined) implementations of `FD_SET` et al expect non-negative integers as file descriptor numbers:
> An fd_set is a fixed size buffer. Executing `FD_CLR()` or `FD_SET()` with a value of `fd` that is negative or is equal to or larger than `FD_SETSIZE` will result in undefined behavior. Moreover, POSIX requires `fd` to be a valid file descriptor.

While some platforms used for initial development apparently were lax about this for whatever reason, on others later on this use of `-1` misfired visibly; I suspect they were made more secure about checking for memory errors (and here we could have had an array underflow, depending on `FD_XXX` implementation as e.g. macros).

This PR proposes a couple of changes:
* Avoid using `ctx->s == -1` in the FD set for `select()` (just in case, do pass that logical code path - e.g. if the system imposes some default file descriptors to consider anyway), and do not `return` from that code path if it failed and we had `ctx->s == -1`.
* Also use libusb-1.0 API (if available in the version we build libmodbus against) to check if the libusb context reports any file descriptors for polling, as explored in https://github.com/networkupstools/nut/issues/2747 -- see https://libusb.sourceforge.io/api-1.0/group__libusb__poll.html#ga54c27dcf8a95d2a3a03cfb7dd37eae63 and https://libusb.sourceforge.io/api-1.0/structlibusb__pollfd.html; if there is exactly one FD reported this way, use it as `ctx->s`.

These changes were tested in https://github.com/networkupstools/nut/issues/2609#issuecomment-2587150448 which collected the device data and did not crash like before.

NOTE: The test `Got a list of 3 libusb file descriptors to poll` and so did not assign any to `ctx->s`; this may need more exploration - what those FDs are and if each should be polled. Maybe change the single `ctx->s` to an array (or to keep code of other RTU's largely unmodified, add the array to backend or even common ctx structure, and use it for `select()` if e.g. `ctx->s==-2`)?