### PR TITLE
Fix mingw build only (rtu_usb specific)

### DIFF
--- a/src/modbus-rtu-usb.c
+++ b/src/modbus-rtu-usb.c
@@ -418,7 +418,9 @@ static int _modbus_rtu_usb_connect(modbus_t *ctx)
     }
 
     if (ctx->debug) {
-        printf("Number of USB devices: %ld\n", devs_len);
+        // Here and below: cast from ssize_t to a portable type big enough for expected
+        // values
+        printf("Number of USB devices: %lld\n", (long long int) devs_len);
     }
 
     for (i = 0; i < devs_len; i++) {
@@ -433,16 +435,16 @@ static int _modbus_rtu_usb_connect(modbus_t *ctx)
         if (r != LIBUSB_SUCCESS) {
             if (ctx->debug) {
                 fprintf(stderr,
-                        "libusb_get_device_descriptor for device #%ld failed: %s\n",
-                        i,
+                        "libusb_get_device_descriptor for device #%lld failed: %s\n",
+                        (long long int) i,
                         libusb_strerror(r));
             }
             continue;
         }
 
         if (ctx->debug) {
-            printf("Considering device #%ld (%04x:%04x)\n",
-                   i,
+            printf("Considering device #%lld (%04x:%04x)\n",
+                   (long long int) i,
                    dev_desc.idVendor,
                    dev_desc.idProduct);
         }
@@ -461,7 +463,9 @@ static int _modbus_rtu_usb_connect(modbus_t *ctx)
         r = libusb_get_port_numbers(d, ud.port_path, sizeof(ud.port_path));
         if (r < 1) {
             if (ctx->debug) {
-                fprintf(stderr, "libusb_get_port_numbers for device #%ld failed\n", i);
+                fprintf(stderr,
+                        "libusb_get_port_numbers for device #%lld failed\n",
+                        (long long int) i);
             }
             continue;
         }
@@ -477,8 +481,8 @@ static int _modbus_rtu_usb_connect(modbus_t *ctx)
         if ((r = libusb_open(d, &dev_handle)) != LIBUSB_SUCCESS) {
             if (ctx->debug) {
                 fprintf(stderr,
-                        "libusb_open for device #%ld failed: %s\n",
-                        i,
+                        "libusb_open for device #%lld failed: %s\n",
+                        (long long int) i,
                         libusb_strerror(r));
             }
             continue;
@@ -540,7 +544,7 @@ static int _modbus_rtu_usb_connect(modbus_t *ctx)
 
         if (is_match) {
             if (ctx->debug) {
-                printf("Found Device %ld (Path %s):\n", i, path_buffer);
+                printf("Found Device %lld (Path %s):\n", (long long int) i, path_buffer);
                 printf("  Vendor ID: 0x%04x\n", ud.vid);
                 printf("  Product ID: 0x%04x\n", ud.pid);
             }

--- a/src/modbus-rtu-usb.c
+++ b/src/modbus-rtu-usb.c
@@ -552,10 +552,11 @@ static int _modbus_rtu_usb_connect(modbus_t *ctx)
             ctx_rtu_usb->device_handle = dev_handle;
 #if defined HAVE_LIBUSB_POLLFD && HAVE_LIBUSB_POLLFD
             if (usb_ctx) {
-                const struct libusb_pollfd** pollfds = libusb_get_pollfds(usb_ctx);
+                const struct libusb_pollfd **pollfds = libusb_get_pollfds(usb_ctx);
                 if (pollfds) {
-                    unsigned	j;
-                    for (j=0; pollfds[j] != NULL; j++) {}
+                    unsigned j;
+                    for (j = 0; pollfds[j] != NULL; j++) {
+                    }
                     if (ctx->debug) {
                         printf("Got a list of %u libusb file descriptors to poll\n", j);
                     }
@@ -576,9 +577,10 @@ static int _modbus_rtu_usb_connect(modbus_t *ctx)
             }
 #else
             if (ctx->debug) {
-                printf("Can not get a list of libusb file descriptors to poll from this libusb version\n");
+                printf("Can not get a list of libusb file descriptors to poll from this "
+                       "libusb version\n");
             }
-#endif	/* HAVE_LIBUSB_POLLFD */
+#endif /* HAVE_LIBUSB_POLLFD */
             break;
         }
 

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -388,7 +388,7 @@ int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
     if (ctx->s < 0) {
         if (ctx->debug) {
             /* we may not have an FD with e.g. libusb usage */
-            fprintf(stderr, "Using a backend without a file descriptor, will not select() on it.\n");
+            fprintf(stderr, "Using a backend without a file descriptor, will not natively select() on it.\n");
         }
     } else {
         FD_SET(ctx->s, &rset);
@@ -444,12 +444,7 @@ int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
                 errno = saved_errno;
 #endif
             }
-            if (ctx->s >= 0) {
-                return -1;
-            }
-            // else: We have at most tried some default FD's but not
-            // the (lacking) one for the backend, so fall through for
-            // its recv method anyway (e.g. query libusb directly).
+            return -1;
         }
 
         rc = ctx->backend->recv(ctx, msg + msg_length, length_to_read);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,10 +16,12 @@ noinst_PROGRAMS += \
 endif
 
 common_ldflags = \
-	$(top_builddir)/src/libmodbus.la \
-	-lusb-1.0
+	$(top_builddir)/src/libmodbus.la
 
 if WITH_LIBUSB
+common_ldflags += \
+	-lusb-1.0
+
 apc_test_client_SOURCES = apc-test-client.c
 apc_test_client_LDADD = $(common_ldflags)
 endif


### PR DESCRIPTION
Separated from PR #3 that also tries to fix tests and code, and may take more time to complete through all the questionable changes into production code (e.g. flushing or not upon reconnection attempts).

Another change set was extracted as https://github.com/networkupstools/libmodbus/pull/4

This subset of those changes focuses more strictly on passing builds without warnings, due to regressions allegedly due to NUT `rtu_usb` branch itself:
* changes in `rtu_usb` branch not as portable as they should be (printing of int types)
* some code style not conforming to defined `clang-format`
* test-building on systems *without* libusb
* revert part of an earlier exploratory fix on the branch, done for invalid socket (the `ctx->s < 0` case): after all, do return if we fail `select()` -- it is not the LIBC one, but the backend-defined one. So in this use-case, the rtu_usb backend does not even care about the `fdset` and has its own ways to decide on success or failure of the communications attempt.