### PR TITLE
rtu-usb: fix several issues

### DIFF
--- a/src/modbus-rtu-usb.c
+++ b/src/modbus-rtu-usb.c
@@ -516,6 +516,8 @@ static int _modbus_rtu_usb_connect(modbus_t *ctx)
             continue;
         }
 
+        libusb_reset_device(dev_handle);
+
         if (dev_desc.iManufacturer) {
             memset(&vendor_buffer, 0, sizeof(vendor_buffer));
             r = libusb_get_string_descriptor_ascii(dev_handle,

--- a/src/modbus-rtu-usb.c
+++ b/src/modbus-rtu-usb.c
@@ -221,11 +221,30 @@ static int _modbus_rtu_usb_receive(modbus_t *ctx, uint8_t *req)
 static ssize_t _modbus_rtu_usb_recv_more(modbus_t *ctx, unsigned int timeout_msecs)
 {
     uint8_t usb_report[_MODBUS_USB_REPORT_SIZE];
-    int transferred, r;
+    int transferred, r, payload_len;
     modbus_rtu_usb_t *ctx_rtu_usb = ctx->backend_data;
 
     if (ctx_rtu_usb->device_handle == NULL) {
         errno = EINVAL;
+        return -1;
+    }
+
+    /* Compact buffer if needed to make room for new data */
+    if (ctx_rtu_usb->usb_buffer_start > 0) {
+        int buffered = ctx_rtu_usb->usb_buffer_end - ctx_rtu_usb->usb_buffer_start;
+        if (buffered > 0) {
+            memmove(ctx_rtu_usb->usb_buffer,
+                    ctx_rtu_usb->usb_buffer + ctx_rtu_usb->usb_buffer_start,
+                    buffered);
+        }
+        ctx_rtu_usb->usb_buffer_start = 0;
+        ctx_rtu_usb->usb_buffer_end = buffered;
+    }
+
+    /* Check if there's room for another report */
+    if (ctx_rtu_usb->usb_buffer_end + _MODBUS_USB_PAYLOAD_SIZE >
+        (int) sizeof(ctx_rtu_usb->usb_buffer)) {
+        errno = ENOBUFS;
         return -1;
     }
 
@@ -249,12 +268,16 @@ static ssize_t _modbus_rtu_usb_recv_more(modbus_t *ctx, unsigned int timeout_mse
         break;
     }
 
-    memcpy(ctx_rtu_usb->usb_buffer + ctx_rtu_usb->usb_buffer_end,
-           usb_report + 1,
-           sizeof(usb_report) - 1);
-    ctx_rtu_usb->usb_buffer_end += sizeof(usb_report) - 1;
+    /* Use actual transferred length minus report ID byte */
+    payload_len = (transferred > 1) ? transferred - 1 : 0;
+    if (payload_len > 0) {
+        memcpy(ctx_rtu_usb->usb_buffer + ctx_rtu_usb->usb_buffer_end,
+               usb_report + 1,
+               payload_len);
+        ctx_rtu_usb->usb_buffer_end += payload_len;
+    }
 
-    return sizeof(usb_report) - 1;
+    return payload_len;
 }
 
 static ssize_t _modbus_rtu_usb_recv(modbus_t *ctx, uint8_t *rsp, int rsp_length)

--- a/src/modbus-rtu-usb.c
+++ b/src/modbus-rtu-usb.c
@@ -149,7 +149,7 @@ static int _modbus_rtu_usb_send_msg_pre(uint8_t *req, int req_length)
 static ssize_t _modbus_rtu_usb_send(modbus_t *ctx, const uint8_t *req, int req_length)
 {
     uint8_t usb_report[_MODBUS_USB_REPORT_SIZE];
-    int to_transfer, transferred, total_transferred, total_remaining, r;
+    int payload_chunk_len, transferred, total_transferred, total_remaining, r;
     modbus_rtu_usb_t *ctx_rtu_usb = ctx->backend_data;
 
     if (ctx_rtu_usb->device_handle == NULL) {
@@ -160,15 +160,18 @@ static ssize_t _modbus_rtu_usb_send(modbus_t *ctx, const uint8_t *req, int req_l
     total_transferred = 0;
     total_remaining = req_length;
     while (total_remaining > 0) {
-        to_transfer = total_remaining % _MODBUS_USB_PAYLOAD_SIZE;
+        /* USB 2.0 Full Speed only supports 64 bytes per transfer,
+         * one byte is used for the report ID, leaving 63 to the payload*/
         usb_report[0] = ctx_rtu_usb->rx_report_id;
-        memcpy(usb_report + 1, req, to_transfer);
-        memset(usb_report + 1 + to_transfer, 0, sizeof(usb_report) - 1 - to_transfer);
+        /* Transfer in payload chunks of 63 until we have less than 63 left */
+        payload_chunk_len = (total_remaining > _MODBUS_USB_PAYLOAD_SIZE)
+            ? _MODBUS_USB_PAYLOAD_SIZE : total_remaining;
+        memcpy(usb_report + 1, req + total_transferred, payload_chunk_len);
 
         r = libusb_interrupt_transfer(ctx_rtu_usb->device_handle,
                                       LIBUSB_ENDPOINT_OUT | ctx_rtu_usb->endpoint,
                                       usb_report,
-                                      sizeof(usb_report),
+                                      payload_chunk_len + 1, /* +1 for report ID */
                                       &transferred,
                                       0);
         if (r != LIBUSB_SUCCESS) {
@@ -176,12 +179,12 @@ static ssize_t _modbus_rtu_usb_send(modbus_t *ctx, const uint8_t *req, int req_l
             return -1;
         }
 
-        total_remaining -= to_transfer;
-        total_transferred += to_transfer;
-
-        if (transferred < to_transfer + 1) {
+        if (transferred < payload_chunk_len + 1) {
             break;
         }
+
+        total_remaining -= transferred - 1;
+        total_transferred += transferred - 1;
     }
 
     return total_transferred;

--- a/tests/apc-test-client.c
+++ b/tests/apc-test-client.c
@@ -81,10 +81,12 @@ int main(void)
         _print_register_int(register_buf, "REG_OUTPUT_0_CURRENT", 5.0f);
     }
 
+    memset(register_buf, 0, sizeof(register_buf));
     if (_read_registers(ctx, 564, 8, register_buf)) {
         _print_register_str(register_buf, "REG_SERIAL_NUMBER", 8);
     }
 
+    memset(register_buf, 0, sizeof(register_buf));
     if (_read_registers(ctx, 532, 16, register_buf)) {
         _print_register_str(register_buf, "REG_MODEL", 16);
     }

--- a/tests/apc-test-client.c
+++ b/tests/apc-test-client.c
@@ -56,7 +56,7 @@ static int _match_callback(const modbus_usb_device_t *device)
 int main(void)
 {
     modbus_t *ctx;
-    uint16_t register_buf[16];
+    uint16_t register_buf[MODBUS_MAX_READ_REGISTERS];
 
     ctx = modbus_new_rtu_usb(MODBUS_USB_MODE_APC, _match_callback);
 
@@ -71,6 +71,18 @@ int main(void)
         fprintf(stderr, "Connection failed: %s\n", modbus_strerror(errno));
         modbus_free(ctx);
         return -1;
+    }
+
+    /* Test a long read of 120 registers.
+     *
+     * MPAO-98KJ7F_R1_EN 4.4.4 Framing:
+     * Shows maximum of 61 + (63 * 3) + 2 = 252 bytes / 2 = 126 registers of payload,
+     * split across 5 interrupt transfers. This is one more than
+     * MODBUS_MAX_READ_REGISTERS (125) but but requesting more than 120 registers
+     * seems to cause immediately return an error response.
+     */
+    if (_read_registers(ctx, 516, 120, register_buf)) {
+        printf("Long read successful\n");
     }
 
     if (_read_registers(ctx, 151, 1, register_buf)) {


### PR DESCRIPTION
* fix send payload chunk size calculation
  The previous calculation of the chunk size was incorrect. The new logic transfers chunks of 63 bytes of payload data until there is less than 63 bytes left, which is then transferred in a final chunk.
* make receive buffer handling safe
  We compact the receive buffer when we can and check if there is still space before writing to it. This should prevent buffer overflows and make the code more robust.
* reset the device after opening it
  This prevents the device from getting into a state where it returns old data as a response after a write.

This also zero initializes the buffer in the test program and adds a test for reading large chunks of registers.